### PR TITLE
Add support for log handler kwargs

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,9 @@ Version 0.2.0
 
 Release TBD
 
+- Add support for log handler kwargs (*Note: this change drops support for
+  Python 3.4 and requires 3.5+*)
+
 
 Version 0.1.0
 =============

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -293,4 +293,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None)}
+intersphinx_mapping = {'python': ('https://docs.python.org/3.5', None)}

--- a/henson_logging/__init__.py
+++ b/henson_logging/__init__.py
@@ -26,6 +26,7 @@ class Logging(Extension):
         'LOG_DATE_FORMAT': None,
         'LOG_FORMAT': '%(message)s\n',
         'LOG_HANDLER': 'logging.StreamHandler',
+        'LOG_HANDLER_KWARGS': {},
         'LOG_LEVEL': 'DEBUG',
         'LOG_VERSION': 1,
 
@@ -81,9 +82,10 @@ class Logging(Extension):
                 },
                 'handlers': {
                     'henson': {
+                        **self.app.settings['LOG_HANDLER_KWARGS'],
                         'class': self.app.settings['LOG_HANDLER'],
                         'formatter': 'henson',
-                    },
+                    }
                 },
                 'loggers': {
                     self.app.name: {

--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,8 @@ setup(
     tests_require=[
         'tox',
     ],
+    classifiers=[
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3 :: Only',
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,py34
+envlist = docs,pep8,py35
 
 [testenv]
 deps =
@@ -10,7 +10,7 @@ commands =
     python -m coverage report -m --include="henson_logging/*"
 
 [testenv:docs]
-basepython = python3.4
+basepython = python3.5
 deps =
     doc8
     sphinx
@@ -20,7 +20,7 @@ commands =
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
 
 [testenv:pep8]
-basepython = python3.4
+basepython = python3.5
 deps =
     flake8-docstrings
     pep8-naming


### PR DESCRIPTION
Allow log handler kwargs to be configured by the application. These args
are passed to the log handler class's `__init__`. This allows
configuration of handler instances such as `logstash.LogstashHandler`.
