### PR TITLE
Add LOG_FORMATTER setting

### DIFF
--- a/henson_logging/__init__.py
+++ b/henson_logging/__init__.py
@@ -25,6 +25,7 @@ class Logging(Extension):
     DEFAULT_SETTINGS = {
         'LOG_DATE_FORMAT': None,
         'LOG_FORMAT': '%(message)s\n',
+        'LOG_FORMATTER': 'henson',
         'LOG_HANDLER': 'logging.StreamHandler',
         'LOG_HANDLER_KWARGS': {},
         'LOG_LEVEL': 'DEBUG',
@@ -84,8 +85,8 @@ class Logging(Extension):
                     'henson': {
                         **self.app.settings['LOG_HANDLER_KWARGS'],
                         'class': self.app.settings['LOG_HANDLER'],
-                        'formatter': 'henson',
-                    }
+                        'formatter': self.app.settings['LOG_FORMATTER'],
+                    },
                 },
                 'loggers': {
                     self.app.name: {


### PR DESCRIPTION
Allow log formatter to be configured. Currently, this allows the log
formatter to be set to `None`; this important for handlers that set
their own formatters (e.g. `logstash.TCPLogstashHandler`). In the
future, formatters other than the `'henson'` default may be provided
by the extension.
