### PR TITLE
Make flake8 ignore E731

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[bdist_wheel]
-universal = 1
+[flake8]
+ignore = E731


### PR DESCRIPTION
Henson-Logging, being a wrapper around Python's stdlib logging module,
sets several attributes by assigning lambdas. This is cleaner than the
alternative in this case, so E731 is being disabled.

Additionally, the universal setting for bdist_wheel is removed, as this
library is only supported on Python 3.5+.