### PR TITLE
Replace Henson's logger

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Version 0.3.0
 =============
 
-Release TBD
+- Replace Henson's logger with the instance of ``Logging``
 
 
 Version 0.2.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,11 +13,11 @@ Quickstart
     from henson import Application
     from henson_logging import Logging
 
-    logger = Logging()
-    app = Application(__name__, logger=logger)
-    logger.init_app(app)
+    app = Application(__name__)
+    logger = Logging(app)
 
-.. todo:: Fix this API. It's awkward.
+In addition to giving you a logger that can be used throughout your
+application, it will replace Henson's internal logger with the new one.
 
 Configuration
 =============

--- a/henson_logging/__init__.py
+++ b/henson_logging/__init__.py
@@ -62,9 +62,10 @@ class Logging(Extension):
 
     def __init__(self, app=None):
         """Initialize the instance."""
-        self._logger = None
-
         super().__init__(app)
+
+        self._logger = None
+        app.logger = self
 
     critical = lambda s, *a, **kw: s.logger.critical(*a, **kw)
     debug = lambda s, *a, **kw: s.logger.debug(*a, **kw)
@@ -73,6 +74,7 @@ class Logging(Extension):
     exception = lambda s, *a, **kw: s.logger.exception(*a, **kw)
     fatal = lambda s, *a, **kw: s.logger.fatal(*a, **kw)
     log = lambda s, *a, **kw: s.logger.log(*a, **kw)
+    setLevel = lambda s, l: s.logger.setLevel(l)
     warning = lambda s, *a, **kw: s.logger.warning(*a, **kw)
 
     @property
@@ -83,7 +85,6 @@ class Logging(Extension):
             logging.RootLogger: The logger.
         """
         if not self._logger:
-
             settings = {
                 'version': self.app.settings['LOG_VERSION'],
                 'formatters': {


### PR DESCRIPTION
When initializing a Henson application, Henson-Logging will now replace
Henson's logger with itself. This will cause all logs for an application
to be formatted with structlog.