### PR TITLE
Fix usage with application factory pattern

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 0.4.0
 
 Release TBD
 
+- Fix usage with application factory pattern
+
 
 Version 0.3.0
 =============

--- a/henson_logging/__init__.py
+++ b/henson_logging/__init__.py
@@ -65,6 +65,15 @@ class Logging(Extension):
         super().__init__(app)
 
         self._logger = None
+
+    def init_app(self, app):
+        """Initialize the application and register a logger.
+
+        Args:
+            app (henson.base.Application): The application to
+                initialize.
+        """
+        super().init_app(app)
         app.logger = self
 
     critical = lambda s, *a, **kw: s.logger.critical(*a, **kw)


### PR DESCRIPTION
``app`` may be ``None`` when calling an extension's ``__init__`` method,
so all logic related to the application must occur inside of or after
``init_app``.