### PR TITLE
Use Sphinx's builtin Napoleon extension

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,4 @@
 doc8
-sphinx
+sphinx>=1.3
 sphinx_rtd_theme
 sphinxcontrib-napoleon

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,9 +34,9 @@ sys.path.insert(0, os.path.abspath('..'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
-    'sphinxcontrib.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Docstrings throughout Henson-Logging adhere to the Google Python Style
Guide.  The Napoleon extension is used to parse them. Rather than
installing it separately, it was graduated to a builtin extension in
Sphinx 1.3