### PR TITLE
Update the Read the Docs domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Henson-Logging |build status|
 
 A library to use structured logging with a Henson application.
 
-* `Documentation <https://henson-logging.rtfd.org>`_
-* `Installation <https://henson-logging.readthedocs.org/en/latest/#installation>`_
-* `Changelog <https://henson-logging.readthedocs.org/en/latest/changes.html>`_
+* `Documentation <https://henson-logging.readthedocs.io>`_
+* `Installation <https://henson-logging.readthedocs.io/en/latest/#installation>`_
+* `Changelog <https://henson-logging.readthedocs.io/en/latest/changes.html>`_
 * `Source <https://github.com/iheartradio/Henson-logging>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Henson-Logging
 ==============
 
 Henson-Logging is a plugin that allows you to easily use structured logging
-(via `structlog <http://structlog.rtfd.org>`_) with a Henson application.
+(via `structlog <http://structlog.readthedocs.io>`_) with a Henson application.
 
 Quickstart
 ==========

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     version='0.4.0',
     author='Andy Dirnberger, Jon Banafato, and others',
     author_email='henson@iheart.com',
-    url='https://henson-logging.rtfd.org',
+    url='https://henson-logging.readthedocs.io',
     description='A library to use structured logging with a Henson application.',
     long_description=read('README.rst'),
     license='Apache License, Version 2.0',


### PR DESCRIPTION
Read the Docs has switched from using readthedocs.org to readthedocs.io
for project documentation. It includes the added benefit of having
better HTTPS support.