### PR TITLE
Cache the logger

### DIFF
--- a/henson_logging/__init__.py
+++ b/henson_logging/__init__.py
@@ -127,6 +127,6 @@ class Logging(Extension):
                 cache_logger_on_first_use=True,
             )
 
-            self._logger = structlog.get_logger(self.app.name)
+            self._logger = structlog.get_logger(self.app.name).bind()
 
         return self._logger


### PR DESCRIPTION
`structlog.get_logger` return a proxy object. This means that each
logging call will generate a new logging instance. This can create
unnecessary overhead if a lot of logging is done (e.g., inside a loop).
Explicitly calling the `bind` method when the logger is first obtained
will remove the proxy object from the equation, allowing the same
logging instance to be used everywhere.