### PR TITLE
Add a way to get and set the logging level

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Release TBD
 - Fix usage with application factory pattern
 - Resolve the logging instance at first access instead of keeping a reference
   to a proxy object
+- Add ``get_effective_level`` and ``set_level`` to set and get the
+  logging level respectively
 
 Version 0.3.1
 =============

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,8 @@
+===
+API
+===
+
+Here's the public API for Henson-Logging.
+
+.. autoclass:: henson_logging.Logging
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -293,4 +293,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3.5', None)}
+intersphinx_mapping = {
+    'henson': ('https://henson.readthedocs.io/en/latest/', None),
+    'python': ('https://docs.python.org/3', None),
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ Contents:
 .. toctree::
    :maxdepth: 1
 
+   api
    changes
 
 

--- a/henson_logging/__init__.py
+++ b/henson_logging/__init__.py
@@ -86,6 +86,21 @@ class Logging(Extension):
     setLevel = lambda s, l: s.logger.setLevel(l)
     warning = lambda s, *a, **kw: s.logger.warning(*a, **kw)
 
+    def get_effective_level(self):
+        """Return the effective level for the logger.
+
+        Returns:
+            int: The effective level.
+
+        .. versionadded:: 0.4
+        """
+        return self.logger.getEffectiveLevel()
+
+    getEffectiveLevel = get_effective_level
+    """An alias for :meth:`get_effective_level` provided for
+    compatibility with :meth:`logging.Logger.getEffectiveLevel`.
+    """
+
     @property
     def logger(self):
         """Return the logger.
@@ -130,3 +145,20 @@ class Logging(Extension):
             self._logger = structlog.get_logger(self.app.name).bind()
 
         return self._logger
+
+    def set_level(self, level):
+        """Set the logging level for the logger.
+
+        Args:
+            level (~typing.Union[int, str]): The logging level to set.
+                If the value is a ``str``, it must be a valid level
+                defined in :mod:`logging`.
+
+        .. versionadded:: 0.4
+        """
+        self.logger.setLevel(level)
+
+    setLevel = set_level
+    """An alias for :meth:`set_level` provided for compatibility with
+    :meth:`logging.Logger.setLevel`.
+    """

--- a/henson_logging/__init__.py
+++ b/henson_logging/__init__.py
@@ -28,7 +28,7 @@ class Logging(Extension):
     """An interface to use structured logging.
 
     Args:
-        app (henson.base.Application, optional): An application
+        app (~typing.Optional[henson.base.Application]): An application
             instance that has an attribute named settings that contains
             a mapping of settings to configure logging.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,14 @@
 
 import logging
 
+from henson import Application
 import pytest
+
+
+@pytest.fixture
+def test_app():
+    """Return a test Application."""
+    return Application('testing')
 
 
 @pytest.fixture

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,23 @@
+"""Test Henson-Logging."""
+
+import logging
+
+import pytest
+
+from henson_logging import Logging
+
+
+@pytest.mark.parametrize('level', (logging.DEBUG, logging.INFO))
+def test_get_effective_level(level, test_app):
+    """Test get_effective_level."""
+    logger = Logging(test_app)
+    logger.logger.setLevel(level)
+    assert logger.get_effective_level() == level
+
+
+@pytest.mark.parametrize('level', (logging.DEBUG, logging.INFO))
+def test_set_level(level, test_app):
+    """Test set_level."""
+    logger = Logging(test_app)
+    logger.set_level(level)
+    assert logger.logger.getEffectiveLevel() == level


### PR DESCRIPTION
In order for `Logging` to be swapped in for `logging.Logger`, certain
methods (beyond just the logging calls) need to be exposed.
`getEffectiveLevel` and `setLevel` are things that can be referenced
outside of Henson-Logging. `get_effective_level` and `set_level` are being
added as the canonical names, with `getEffectiveLevel` and
`setLevel` being added for API compatibility.

The documentation is also being updated to include `Logging`'s public
API.