### PR TITLE
Update To Python 3.8 and 3.9, drop support for everything below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: python
 
 matrix:
   include:
-    - python: 3.5
-      env: TOX_ENV=py35
-    - python: 3.6
-      env: TOX_ENV=py36
-    - python: 3.6
+    - python: 3.8
+      env: TOX_ENV=py38
+    - python: 3.9
+      env: TOX_ENV=py39
+    - python: 3.9
       env: TOX_ENV=docs
-    - python: 3.6
+    - python: 3.9
       env: TOX_ENV=pep8
 
 install: pip install tox

--- a/henson_logging/__init__.py
+++ b/henson_logging/__init__.py
@@ -83,7 +83,7 @@ class Logging(Extension):
     exception = lambda s, *a, **kw: s.logger.exception(*a, **kw)
     fatal = lambda s, *a, **kw: s.logger.fatal(*a, **kw)
     log = lambda s, *a, **kw: s.logger.log(*a, **kw)
-    setLevel = lambda s, l: s.logger.setLevel(l)
+    setLevel = lambda s, l: s.logger.setLevel(l)  # NOQA: N815
     warning = lambda s, *a, **kw: s.logger.warning(*a, **kw)
 
     def get_effective_level(self):
@@ -97,7 +97,7 @@ class Logging(Extension):
         """
         return self.logger.getEffectiveLevel()
 
-    getEffectiveLevel = get_effective_level
+    getEffectiveLevel = get_effective_level  # NOQA: N815
     """An alias for :meth:`get_effective_level` provided for
     compatibility with :meth:`logging.Logger.getEffectiveLevel`.
     """
@@ -160,7 +160,7 @@ class Logging(Extension):
         """
         self.logger.setLevel(level)
 
-    setLevel = set_level
+    setLevel = set_level  # NOQA: N815
     """An alias for :meth:`set_level` provided for compatibility with
     :meth:`logging.Logger.setLevel`.
     """

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ def read(filename):
 
 setup(
     name='Henson-Logging',
-    version='0.4.0',
-    author='Andy Dirnberger, Jon Banafato, and others',
+    version='0.5.0',
+    author='Andy Dirnberger, Jon Banafato, Leonard Bedner, and others',
     author_email='henson@iheart.com',
     url='https://henson-logging.readthedocs.io',
     description='A library to use structured logging with a Henson application.',
@@ -46,8 +46,8 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,23 @@
 [tox]
-envlist = docs,pep8,py35,py36
+envlist = docs,pep8,py38,py39
 
 [testenv]
 deps =
     coverage
     pytest
 commands =
-    python -m coverage run -m pytest --strict {posargs: tests}
+    python -m coverage run -m pytest --strict-markers {posargs: tests}
     python -m coverage report -m --include="henson_logging/*"
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3.9
 deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
 
 [testenv:pep8]
-basepython = python3.6
+basepython = python3.9
 deps =
     flake8-docstrings
     pep8-naming


### PR DESCRIPTION
- remove support for Python <= 3.7
- add support for Python >= 3.8
- ignore `pep8` `N815`, since the `logging` module was created so long ago before snake_case became the de-facto standard, as it was essentially modeled after log4j 