### PR TITLE
Update henson logging to allow propagate to be configurable

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,3 +7,4 @@ The following folks have contributed to making this library possible.
 * Andy Dirnberger (`@dirn <https://github.com/dirn>`_)
 * Jon Banafato (`@jonafato <https://github.com/jonafato>`_)
 * Leonard Bedner (`@lbedner <https://github.com/lbedner>`_)
+* Bo Guthrie (`@boguth <https://github.com/boguth>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+Version 0.6.0
+=============
+
+Released 2021-03-25
+
+- Allows the propagate logging property to be configured
+
 Version 0.5.0
 =============
 

--- a/henson_logging/__init__.py
+++ b/henson_logging/__init__.py
@@ -58,6 +58,7 @@ class Logging(Extension):
         'LOG_CONTEXT_CLASS': dict,
         'LOG_FACTORY': structlog.stdlib.LoggerFactory(),
         'LOG_WRAPPER_CLASS': structlog.stdlib.BoundLogger,
+        'LOG_PROPAGATE': True,
     }
 
     def __init__(self, app=None):
@@ -74,8 +75,18 @@ class Logging(Extension):
                 initialize.
         """
         super().init_app(app)
+        # the lines defining log levels (critical, debug, etc)
+        # use the state of Henson base logger's (app.logger).
+        # In order to prevent the current henson_logging.Logger
+        # object from passing its log events to the Henson base
+        # logger's handler when invoking functions set in those lines,
+        # propagate must be false.
+        app.logger.propagate = app.settings['LOG_PROPAGATE']
         app.logger = self
 
+    # the invocation of these lambda functions rely on the state
+    # of s.logger (henson.base.Logger)
+    # at the time of variable setting
     critical = lambda s, *a, **kw: s.logger.critical(*a, **kw)
     debug = lambda s, *a, **kw: s.logger.debug(*a, **kw)
     error = lambda s, *a, **kw: s.logger.error(*a, **kw)

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ def read(filename):
 
 setup(
     name='Henson-Logging',
-    version='0.5.0',
-    author='Andy Dirnberger, Jon Banafato, Leonard Bedner, and others',
+    version='0.6.0',
+    author='Andy Dirnberger, Jon Banafato, Leonard Bedner, Bo Guthrie, and others',
     author_email='henson@iheart.com',
     url='https://henson-logging.readthedocs.io',
     description='A library to use structured logging with a Henson application.',


### PR DESCRIPTION
https://ihm-it.atlassian.net/browse/IHRACP-3480

tl;dr - we're duplicating logs because we have a parent logger writing to stderr and a child logger writing to stdout. Turning propagate to false keeps events from being passed from the child logger to the parent logger so that we only output logs once to stdout. 

Service applications implement the following code: 
```py
    app = Application(name) 
```
which calls this: 
```py
# instantiates a base python logger which inherits from the root logger.
# also implicitly sets a StreamHandler to the root logger which outputs to stderr
self.logger = logging.getLogger(self.name) # henson/base.py:64
```

Next, we typically call this in our service applications: 
```py
logger.init_app(app)
```
which causes any subsequent invocations of `logger` to invoke code which on first pass does this: 
```py
    # henson_logging/__init__.py:130
    'handlers': {
        'henson': {
            **self.app.settings['LOG_HANDLER_KWARGS'], <-- sets output to stdout
            'class': self.app.settings['LOG_HANDLER'],
            'formatter': self.app.settings['LOG_FORMATTER'],
        },
    }, 
    
   ....

  # henson_logging/__init__.py:147
  structlog.configure(
      processors=self.app.settings['LOG_PROCESSORS'],
      context_class=self.app.settings['LOG_CONTEXT_CLASS'],
      logger_factory=self.app.settings['LOG_FACTORY'], # 
     #^^^^^^ binds any subsequent structlog.get_logger calls to stdlib, which inherits from the root logger https://www.structlog.org/en/stable/api.html#structlog.stdlib.LoggerFactory or https://www.structlog.org/en/stable/getting-started.html#structlog-and-standard-library-s-logging
      wrapper_class=self.app.settings['LOG_WRAPPER_CLASS'],
      cache_logger_on_first_use=True,
  )

  self._logger = structlog.get_logger(self.app.name).bind()
```

This result of all this means that we now have two StreamHandlers, one handling events emitted by our logger and one handling events emitted by our base python logger - both of which inherit from the root logger. 

Each logger has a propagate setting which defaults to true. If it is true then:
```

 ...events logged to this logger will be passed to the handlers of higher level (ancestor) loggers, in addition to any handlers attached to this logger. Messages are passed directly to the ancestor loggers’ handlers - neither the level nor filters of the ancestor loggers in question are considered.

```
Reference: https://docs.python.org/3/library/logging.html#logging.Logger.propagate. 

This was causing us to outputs logs twice. Once to stdout and then to stderr. If we set propogate to false, this issue will stop. So I made that a configurable option. 
